### PR TITLE
Fix wrong subref call on content.

### DIFF
--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -263,7 +263,7 @@ sub _log_text {
     return unless $content;
 
     if ( $self->text_pre_filter ) {
-        $content = $self->content_pre_filter->( $content, $content_type );
+        $content = $self->text_pre_filter->( $content, $content_type );
     }
 
     return unless $content;


### PR DESCRIPTION
This fixes an `Can't use an undefined value as a subroutine reference` warning when only `text_pre_filter` was specified.
