### PR TITLE
set term_width to 80

### DIFF
--- a/t/LWP/ConsoleLogger/Easy.t
+++ b/t/LWP/ConsoleLogger/Easy.t
@@ -166,6 +166,7 @@ sub test_content {
         )
     );
 
+    $logger->term_width(80);
     $logger->logger($ld);
 
     my $app = sub {

--- a/t/LWP/ConsoleLogger/Easy.t
+++ b/t/LWP/ConsoleLogger/Easy.t
@@ -67,6 +67,7 @@ EOF
         'application/javascript',
         sub {
             my $text = shift;
+	    $text =~ s/-[\s|]+//g;
             ok( $text =~ /^| var baz/m,    'leading whitespace is trimmed' );
             ok( $text =~ /magna al\.\.\./, 'text is cut off at 255 chars' );
         }
@@ -166,7 +167,6 @@ sub test_content {
         )
     );
 
-    $logger->term_width(80);
     $logger->logger($ld);
 
     my $app = sub {


### PR DESCRIPTION
CPAN PRC :-)

This should prevent unit test from depending on system's term width:

http://www.cpantesters.org/cpan/report/17e6f288-b3d6-11e6-b68e-b4ce77eefe28

`
dolore magna- |
|  al...     
`

`
 ok( $text =~ /magna al\.\.\./, 'text is cut off at 255 chars' );
`
