### PR TITLE
Include Mojo::UA in LWP::ConsoleLogger::Everywhere

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for LWP-ConsoleLogger
 
 {{$NEXT}}
+    - Add support for Mojo::UserAgent to LWP::ConsoleLogger::Everywhere (simbabque)
 
 0.000040  2019-06-11 01:22:03Z
     - Add support for Mojo::UserAgent (GH#14) (Gregory Oschwald)

--- a/t/LWP/ConsoleLogger/Everywhere.t
+++ b/t/LWP/ConsoleLogger/Everywhere.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Capture::Tiny 'capture_stderr';
 use Path::Tiny qw( path );
+use Module::Runtime qw( require_module );
 use Test::FailWarnings -allow_deps => 1;
 use Test::Fatal qw( exception );
 use Test::More;
@@ -11,44 +12,74 @@ use WWW::Mechanize;
 
 use LWP::ConsoleLogger::Everywhere;
 
-my $foo = 'file://' . path('t/test-data/foo.html')->absolute;
+my $url = 'file://' . path('t/test-data/foo.html')->absolute;
 
 my $lwp  = LWP::UserAgent->new( cookie_jar => {} );
 my $mech = WWW::Mechanize->new( autocheck  => 0 );
 
-foreach my $ua ( $lwp, $mech ) {
+my ($mojo, $mojo_based);
+if ( require_module('Mojo::UserAgent') ) {
+    $mojo = Mojo::UserAgent->new;
+
+    {
+        # we need this to test with agents that are subclassing Mojo::UA
+        package Foo::Mojobased;
+        main::require_module('Mojo::Base');
+        Mojo::Base->import('Mojo::UserAgent');
+
+        sub new {
+            my $class = shift;
+            my $self = $class->SUPER::new(@_);
+            return $self;
+        }
+    }
+    package main;
+
+    $mojo_based = Foo::Mojobased->new;
+}
+
+foreach my $ua ( $lwp, $mech, $mojo, $mojo_based ) {
     my $stderr = capture_stderr sub {
         is(
             exception {
-                $mech->get($foo);
+                $ua->get($url);
             },
             undef,
-            'code lives'
+            'Same package: GETing with ' . ref($ua) .' lives'
         );
     };
-    ok $stderr, 'there was a dump';
+    ok $stderr, '... and there was a dump';
 }
 
 {
-
     package Foo::Bar;
 
     our $lwp  = LWP::UserAgent->new( cookie_jar => {} );
     our $mech = WWW::Mechanize->new( autocheck  => 0 );
+
+    our ( $mua, $mua_based );
+    if ($mojo) {
+        $mua       = Mojo::UserAgent->new;
+        $mua_based = Foo::Mojobased->new;
+    }
 }
 
-foreach my $ua ( $Foo::Bar::lwp, $Foo::Bar::mech ) {
+package main;
+
+foreach my $ua ( $Foo::Bar::lwp, $Foo::Bar::mech, $Foo::Bar::mua, $Foo::Bar::mua_based ) {
+    next unless $ua; # skip mojo if it's not installed
+
     my $stderr = capture_stderr sub {
         is(
             exception {
-                $mech->get($foo);
+                $ua->get($url);
             },
             undef,
-            'code lives'
+            'Different package: GETing with ' . ref($ua) .' lives'
         );
     };
     diag $stderr;
-    ok $stderr, 'there was a dump';
+    ok $stderr, '... and there was a dump';
 }
 
 is(
@@ -56,7 +87,8 @@ is(
         grep { $_->isa('LWP::ConsoleLogger') }
             @{ LWP::ConsoleLogger::Everywhere->loggers }
     ),
-    4,
+    4 + defined($mojo) + defined($mojo_based) + defined($Foo::Bar::mua)
+      + defined($Foo::Bar::mua_based),
     'all loggers are stored'
 );
 
@@ -73,7 +105,8 @@ is(
         grep { $_->dump_content == 0 }
             @{ LWP::ConsoleLogger::Everywhere->loggers }
     ),
-    4,
+    4 + defined($mojo) + defined($mojo_based) + defined($Foo::Bar::mua)
+      + defined($Foo::Bar::mua_based),
     '... and all loggers have been changed'
 );
 


### PR DESCRIPTION
Also fixes a bug in the Everywhere.t that skipped the regular LWP objects.