### PR TITLE
Mojo requires is_success() method.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,7 +17,7 @@ Log::Dispatch = 2.56
 HTML::FormatText::Lynx = 23
 
 [Prereqs / TestRecommends]
-Mojolicious = 0
+Mojolicious = 7.13
 Mojo::UserAgent = 0
 Pithub = 0
 


### PR DESCRIPTION
See https://github.com/oalders/lwp-consolelogger/issues/15#issuecomment-500690977

Fixes #15 