### PR TITLE
Recognise subtype soap+xml

### DIFF
--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -364,7 +364,7 @@ sub _get_content {
     if (
         ( $type ne 'text' )
         && ( none { $_ eq $subtype }
-            ( 'javascript', 'html', 'json', 'xml', 'x-www-form-urlencoded', )
+            ( 'javascript', 'html', 'json', 'xml', 'soap+xml', 'x-www-form-urlencoded', )
         )
         && $subtype !~ m{$json_regex}
     ) {


### PR DESCRIPTION
Simple tweak - recognises the subtype soap+xml for those unfortunate enough to
have to look at SOAP XML stuff.

Without this, using the excellent LWP::ConsoleLogger::Everywhere to dump out the
interactions with the EU's VIES VAT checking SOAP API was rather unhelpful, with
the content redacted.

I do wonder if there should be a conveniently easy way to say "just dump the raw
request and response, whatever content-type it is" or a way to provide custom
"also dump this content-type" config at runtime easily.
