### PR TITLE
Adapt to Test-More-0.39

### DIFF
--- a/t/LWP/ConsoleLogger.t
+++ b/t/LWP/ConsoleLogger.t
@@ -8,7 +8,7 @@ use LWP::ConsoleLogger ();
 use LWP::UserAgent     ();
 use Path::Tiny         qw( path );
 use Test::Fatal        qw( exception );
-use Test::Most import => [qw( diag done_testing is ok )];
+use Test::Most;
 use URI::file      ();
 use WWW::Mechanize ();
 

--- a/t/LWP/ConsoleLogger/Easy.t
+++ b/t/LWP/ConsoleLogger/Easy.t
@@ -14,7 +14,7 @@ use Plack::Test                          ();
 use Plack::Test::Agent                   ();
 use Test::Warnings;
 use Test::Fatal qw( exception );
-use Test::Most import => [qw( diag done_testing is is_deeply ok skip )];
+use Test::Most;
 use Try::Tiny      qw( catch try );
 use WWW::Mechanize ();
 


### PR DESCRIPTION
Test-More-0.39 changed how import() arguments are handled in 7d20ddb1213efeee2738b7c5cae5d0450a47dec1 commit (Localisation of @EXPORT was "necessary but not sufficient"...) as as a result tests failed like this:

    $ perl -I/tmp/test--most/lib/ -Ilib t/LWP/ConsoleLogger.t
    plan() doesn't understand import ARRAY(0x560abfc8a9c8) at t/LWP/ConsoleLogger.t line 11.
    BEGIN failed--compilation aborted at t/LWP/ConsoleLogger.t line 11.

The cause was that t/LWP/ConsoleLogger.t attempted to pass a reference to an explicit list of symbols to export to Test::Most::import(). That was never documented or tested in Test::Most documentation. It only documents explicit exclusion of the import.

This patch simply removes the explicit import list because I was unable achieve the same effect with the new Test::Most and at the and a philosophy of Test::Most is to do things automatically. Not not to do them.