### PR TITLE
Fix mojibake on non-ASCII headers, cookies, and titles (#38)

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ Revision history for LWP-ConsoleLogger
     - Open the LWPCL_LOGFILE log file with a UTF-8 layer in
       LWP::ConsoleLogger::Everywhere to stop "Wide character in print"
       warnings (GH#38).
+    - Non-pretty header dumps now honor headers_to_redact, matching the
+      pretty-mode behavior.
 
 1.000001  2023-06-21 16:14:51Z
     - Enable selection of log filename from environment variable (GH#28) (Håkon

--- a/Changes
+++ b/Changes
@@ -5,6 +5,12 @@ Revision history for LWP-ConsoleLogger
       Term::Table to fix box-border misalignment when output contains
       wide characters such as emoji or CJK glyphs (GH#49). Border style
       changes from .-/' corners to +/-.
+    - Decode non-ASCII HTTP header values, cookie field values, and the
+      user agent's title to character strings before logging, so they
+      no longer render as mojibake (GH#38).
+    - Open the LWPCL_LOGFILE log file with a UTF-8 layer in
+      LWP::ConsoleLogger::Everywhere to stop "Wide character in print"
+      warnings (GH#38).
 
 1.000001  2023-06-21 16:14:51Z
     - Enable selection of log filename from environment variable (GH#28) (Håkon

--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ App::perlvars = 0
 
 [Prereqs]
 Data::Printer = 0.36
+Encode        = 0
 JSON::MaybeXS = 1.003005
 Log::Dispatch = 2.56
 Term::Table   = 0.028
@@ -31,6 +32,9 @@ perl = 5.016 ; Mojo dep in tests
 HTML::FormatText::Lynx = 23
 Unicode::GCString      = 0
 XML::Simple            = 0
+
+[Prereqs / TestRequires]
+IPC::Run3 = 0
 
 [Prereqs / TestRecommends]
 Mojolicious = 7.13

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -225,7 +225,7 @@ sub _log_headers {
         my $val
             = ( any { $name eq $_ } @{ $self->headers_to_redact } )
             ? '[REDACTED]'
-            : $headers->header($name);
+            : $self->_decode_header_value( $headers->header($name) );
         push @rows, [ $name, $val ];
     }
 

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -318,6 +318,8 @@ sub _log_cookies {
                 if ($val) {
                     $val = DateTime->from_epoch( epoch => $val )
                         if $method eq 'expires';
+                    $val = $self->_decode_header_value($val)
+                        unless ref $val;    # leave DateTime objects alone
                     push @rows, [ $method, $val ];
                 }
             }
@@ -338,6 +340,8 @@ sub _log_cookies {
                 if ( $val && $key =~ m{expires|_time} ) {
                     $val = DateTime->from_epoch( epoch => $val );
                 }
+                $val = $self->_decode_header_value($val)
+                    if defined $val && !ref $val;
                 push @rows, [ $key, $val ];
             }
 

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -216,7 +216,16 @@ sub _log_headers {
     return if !$self->dump_headers;
 
     unless ( $self->pretty ) {
-        $self->_debug( $headers->as_string );
+        my $out = q{};
+        foreach my $name ( sort $headers->header_field_names ) {
+            my $val
+                = ( any { $name eq $_ } @{ $self->headers_to_redact } )
+                ? '[REDACTED]'
+                : $self->_decode_header_value( $headers->header($name) );
+            $val = q{} unless defined $val;
+            $out .= "$name: $val\n";
+        }
+        $self->_debug($out);
         return;
     }
 

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -218,12 +218,15 @@ sub _log_headers {
     unless ( $self->pretty ) {
         my $out = q{};
         foreach my $name ( sort $headers->header_field_names ) {
-            my $val
-                = ( any { $name eq $_ } @{ $self->headers_to_redact } )
-                ? '[REDACTED]'
-                : $self->_decode_header_value( $headers->header($name) );
-            $val = q{} unless defined $val;
-            $out .= "$name: $val\n";
+            if ( any { $name eq $_ } @{ $self->headers_to_redact } ) {
+                $out .= "$name: [REDACTED]\n";
+                next;
+            }
+            for my $val ( $headers->header($name) ) {
+                $val = q{} unless defined $val;
+                $out .= "$name: "
+                    . $self->_decode_header_value($val) . "\n";
+            }
         }
         $self->_debug($out);
         return;

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -189,7 +189,8 @@ sub response_callback {
         $self->_debug( '==> ' . $res->status_line . "\n" );
     }
     if ( $self->dump_title && $ua->can('title') && $ua->title ) {
-        $self->_debug( 'Title: ' . $ua->title . "\n" );
+        $self->_debug(
+            'Title: ' . $self->_decode_header_value( $ua->title ) . "\n" );
     }
 
     $self->_log_headers( 'response', $res->headers );

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -208,7 +208,7 @@ sub _decode_header_value {
 
     my $decoded = eval { Encode::decode( 'UTF-8', $val, Encode::FB_CROAK ) };
     return $decoded if defined $decoded;
-    return Encode::decode( 'iso-8859-1', $val );    # never fails on byte strings
+    return Encode::decode( 'iso-8859-1', $val ); # never fails on byte strings
 }
 
 sub _log_headers {
@@ -225,8 +225,7 @@ sub _log_headers {
             }
             for my $val ( $headers->header($name) ) {
                 $val = q{} unless defined $val;
-                $out .= "$name: "
-                    . $self->_decode_header_value($val) . "\n";
+                $out .= "$name: " . $self->_decode_header_value($val) . "\n";
             }
         }
         $self->_debug($out);

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -218,7 +218,7 @@ sub _log_headers {
 
     unless ( $self->pretty ) {
         my $out = q{};
-        foreach my $name ( sort $headers->header_field_names ) {
+        foreach my $name ( $headers->header_field_names ) {
             if ( any { $name eq $_ } @{ $self->headers_to_redact } ) {
                 $out .= "$name: [REDACTED]\n";
                 next;

--- a/lib/LWP/ConsoleLogger.pm
+++ b/lib/LWP/ConsoleLogger.pm
@@ -9,6 +9,7 @@ our $VERSION = '1.000002';
 
 use Data::Printer { end_separator => 1, hash_separator => ' => ' };
 use DateTime                  ();
+use Encode                    ();
 use HTML::Restrict            ();
 use HTTP::Body                ();
 use HTTP::CookieMonster       ();
@@ -197,6 +198,16 @@ sub response_callback {
     $self->_log_content($res);
     $self->_log_text($res);
     return;
+}
+
+sub _decode_header_value {
+    my ( $self, $val ) = @_;
+    return $val unless defined $val && length $val;
+    return $val if utf8::is_utf8($val);
+
+    my $decoded = eval { Encode::decode( 'UTF-8', $val, Encode::FB_CROAK ) };
+    return $decoded if defined $decoded;
+    return Encode::decode( 'iso-8859-1', $val );    # never fails on byte strings
 }
 
 sub _log_headers {

--- a/lib/LWP/ConsoleLogger/Everywhere.pm
+++ b/lib/LWP/ConsoleLogger/Everywhere.pm
@@ -20,7 +20,12 @@ my $dispatch_logger;
         my $filename = $ENV{$key};
         $dispatch_logger = Log::Dispatch->new(
             outputs => [
-                [ 'File', min_level => 'debug', filename => $filename ],
+                [
+                    'File',
+                    min_level => 'debug',
+                    filename  => $filename,
+                    binmode   => ':encoding(UTF-8)',
+                ],
             ],
         );
     }

--- a/t/decode-header-value.t
+++ b/t/decode-header-value.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Encode qw( encode_utf8 );
+use LWP::ConsoleLogger ();
+use Test::More import => [qw( done_testing is ok subtest )];
+use Test::Warnings;
+
+my $cl = LWP::ConsoleLogger->new;
+
+subtest 'undef returns undef' => sub {
+    is( $cl->_decode_header_value(undef), undef, 'undef passes through' );
+};
+
+subtest 'empty string returns empty' => sub {
+    is( $cl->_decode_header_value(q{}), q{}, 'empty string passes through' );
+};
+
+subtest 'pure ASCII bytes return equivalent characters' => sub {
+    my $got = $cl->_decode_header_value('hello');
+    is( $got, 'hello', 'ASCII passes through' );
+};
+
+subtest 'raw UTF-8 bytes are decoded' => sub {
+    my $bytes = encode_utf8("\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}");
+    my $got   = $cl->_decode_header_value($bytes);
+    is( $got, "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}",
+        'UTF-8 bytes decoded to Greek characters' );
+    ok( utf8::is_utf8($got), 'result has utf8 flag' );
+};
+
+subtest 'invalid UTF-8 falls back to Latin-1' => sub {
+    # \xE9 alone is not valid UTF-8 (it would start a 3-byte sequence)
+    my $got = $cl->_decode_header_value("\xE9");
+    is( $got, "\x{00E9}", 'Latin-1 byte decoded as character é' );
+};
+
+subtest 'already-decoded character string is preserved' => sub {
+    my $chars = "\x{03B1}";
+    my $got   = $cl->_decode_header_value($chars);
+    is( $got, "\x{03B1}", 'decoded char passes through unchanged' );
+};
+
+done_testing;

--- a/t/decode-header-value.t
+++ b/t/decode-header-value.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Encode qw( encode_utf8 );
+use Encode             qw( encode_utf8 );
 use LWP::ConsoleLogger ();
 use Test::More import => [qw( done_testing is ok subtest )];
 use Test::Warnings;
@@ -22,14 +22,18 @@ subtest 'pure ASCII bytes return equivalent characters' => sub {
 };
 
 subtest 'raw UTF-8 bytes are decoded' => sub {
-    my $bytes = encode_utf8("\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}");
-    my $got   = $cl->_decode_header_value($bytes);
-    is( $got, "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}",
-        'UTF-8 bytes decoded to Greek characters' );
+    my $bytes
+        = encode_utf8("\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}");
+    my $got = $cl->_decode_header_value($bytes);
+    is(
+        $got, "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}",
+        'UTF-8 bytes decoded to Greek characters'
+    );
     ok( utf8::is_utf8($got), 'result has utf8 flag' );
 };
 
 subtest 'invalid UTF-8 falls back to Latin-1' => sub {
+
     # \xE9 alone is not valid UTF-8 (it would start a 3-byte sequence)
     my $got = $cl->_decode_header_value("\xE9");
     is( $got, "\x{00E9}", 'Latin-1 byte decoded as character é' );

--- a/t/everywhere-logfile-child.pl
+++ b/t/everywhere-logfile-child.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use LWP::ConsoleLogger::Everywhere ();    # reads $ENV{LWPCL_LOGFILE} at use time
+use LWP::ConsoleLogger::Everywhere (); # reads $ENV{LWPCL_LOGFILE} at use time
 use LWP::UserAgent                 ();
 use Path::Tiny                     qw( path );
 

--- a/t/everywhere-logfile-child.pl
+++ b/t/everywhere-logfile-child.pl
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+
+use LWP::ConsoleLogger::Everywhere ();    # reads $ENV{LWPCL_LOGFILE} at use time
+use LWP::UserAgent                 ();
+use Path::Tiny                     qw( path );
+
+my $url = 'file:///' . path('t/test-data/unicode.html')->absolute;
+my $ua  = LWP::UserAgent->new;
+$ua->get($url);
+exit 0;

--- a/t/everywhere-logfile.t
+++ b/t/everywhere-logfile.t
@@ -19,8 +19,10 @@ subtest 'LWPCL_LOGFILE writes UTF-8 without Wide-character warnings' => sub {
     is( $? >> 8, 0, 'child exited cleanly' )
         or diag "stderr: $stderr";
 
-    unlike( $stderr, qr/Wide character in print/,
-        'no "Wide character in print" warnings emitted' );
+    unlike(
+        $stderr, qr/Wide character in print/,
+        'no "Wide character in print" warnings emitted'
+    );
 
     my $bytes = path($logfile)->slurp_raw;
     like( $bytes, qr/\xF0\x9F\x98\x84/, '😄 UTF-8 bytes present in log file' );

--- a/t/everywhere-logfile.t
+++ b/t/everywhere-logfile.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+
+use File::Temp qw( tempfile );
+use IPC::Run3  qw( run3 );
+use Path::Tiny qw( path );
+use Test::More import => [qw( diag done_testing is like ok subtest unlike )];
+use Test::Warnings;
+
+subtest 'LWPCL_LOGFILE writes UTF-8 without Wide-character warnings' => sub {
+    my ( undef, $logfile ) = tempfile( UNLINK => 1 );
+
+    my @cmd = ( $^X, '-Ilib', 't/everywhere-logfile-child.pl' );
+    my ( $stdout, $stderr );
+    {
+        local $ENV{LWPCL_LOGFILE} = $logfile;
+        run3( \@cmd, \undef, \$stdout, \$stderr );
+    }
+    is( $? >> 8, 0, 'child exited cleanly' )
+        or diag "stderr: $stderr";
+
+    unlike( $stderr, qr/Wide character in print/,
+        'no "Wide character in print" warnings emitted' );
+
+    my $bytes = path($logfile)->slurp_raw;
+    like( $bytes, qr/\xF0\x9F\x98\x84/, '😄 UTF-8 bytes present in log file' );
+};
+
+done_testing;

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -1,17 +1,69 @@
 use strict;
 use warnings;
 
+use File::Temp        qw( tempfile );
+use LWP::ConsoleLogger ();
 use LWP::ConsoleLogger::Easy qw( debug_ua );
 use LWP::UserAgent           ();
+use Log::Dispatch            ();
 use Path::Tiny               qw( path );
+use Test::More import => [qw( done_testing is ok like subtest )];
 use Test::Warnings;
-use Test::More import => [qw( done_testing is )];
 
-my $mech = LWP::UserAgent->new;
-debug_ua($mech);
+my $url = 'file:///' . path('t/test-data/unicode.html')->absolute;
+my $smile = "\x{1F604}";    # 😄
 
-my $res
-    = $mech->get( 'file:///' . path('t/test-data/unicode.html')->absolute );
-is( $res->code, 200, 'got unicode file' );
+subtest 'body content with unicode renders correctly via Code logger' => sub {
+    my @captured;
+    my $logger = Log::Dispatch->new(
+        outputs => [
+            [
+                'Code',
+                min_level => 'debug',
+                code      => sub {
+                    my %args = @_;
+                    push @captured, $args{message};
+                },
+            ],
+        ],
+    );
 
-done_testing();
+    my $mech   = LWP::UserAgent->new;
+    my $cl     = debug_ua($mech);
+    $cl->logger($logger);
+
+    my $res = $mech->get($url);
+    is( $res->code, 200, 'fetched unicode.html' );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/\Q$smile\E/, '😄 present in captured output' );
+};
+
+subtest 'no Wide character warnings when writing to a File output' => sub {
+    my ( undef, $tmp ) = tempfile( UNLINK => 1 );
+
+    my $logger = Log::Dispatch->new(
+        outputs => [
+            [
+                'File',
+                min_level => 'debug',
+                filename  => $tmp,
+                binmode   => ':encoding(UTF-8)',
+            ],
+        ],
+    );
+
+    my $mech = LWP::UserAgent->new;
+    my $cl   = debug_ua($mech);
+    $cl->logger($logger);
+
+    # Test::Warnings (use'd at top of file) will fail the test if any warning
+    # fires during the run.
+    my $res = $mech->get($url);
+    is( $res->code, 200, 'fetched unicode.html for file output test' );
+
+    my $bytes = path($tmp)->slurp_raw;
+    like( $bytes, qr/\xF0\x9F\x98\x84/, '😄 UTF-8 bytes present in log file' );
+};
+
+done_testing;

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use File::Temp        qw( tempfile );
-use LWP::ConsoleLogger ();
+use File::Temp               qw( tempfile );
+use LWP::ConsoleLogger       ();
 use LWP::ConsoleLogger::Easy qw( debug_ua );
 use LWP::UserAgent           ();
 use Log::Dispatch            ();
@@ -10,8 +10,8 @@ use Path::Tiny               qw( path );
 use Test::More import => [qw( done_testing is ok like subtest )];
 use Test::Warnings;
 
-my $url = 'file:///' . path('t/test-data/unicode.html')->absolute;
-my $smile = "\x{1F604}";    # 😄
+my $url   = 'file:///' . path('t/test-data/unicode.html')->absolute;
+my $smile = "\x{1F604}";                                               # 😄
 
 subtest 'body content with unicode renders correctly via Code logger' => sub {
     my @captured;
@@ -28,8 +28,8 @@ subtest 'body content with unicode renders correctly via Code logger' => sub {
         ],
     );
 
-    my $mech   = LWP::UserAgent->new;
-    my $cl     = debug_ua($mech);
+    my $mech = LWP::UserAgent->new;
+    my $cl   = debug_ua($mech);
     $cl->logger($logger);
 
     my $res = $mech->get($url);

--- a/t/utf8-cookies.t
+++ b/t/utf8-cookies.t
@@ -1,14 +1,14 @@
 use strict;
 use warnings;
 
-use Encode       qw( encode_utf8 );
-use HTTP::Cookies      ();
+use Encode               qw( encode_utf8 );
+use HTTP::Cookies        ();
 use HTTP::CookieJar::LWP ();
-use HTTP::Headers      ();
-use HTTP::Request   ();
-use HTTP::Response  ();
-use Log::Dispatch   ();
-use LWP::ConsoleLogger ();
+use HTTP::Headers        ();
+use HTTP::Request        ();
+use HTTP::Response       ();
+use Log::Dispatch        ();
+use LWP::ConsoleLogger   ();
 use Test::More import => [qw( done_testing like unlike subtest )];
 use Test::Warnings;
 
@@ -16,13 +16,14 @@ use Test::Warnings;
     package Fake::UA;
     sub new        { bless { jar => $_[1] }, $_[0] }
     sub cookie_jar { $_[0]->{jar} }
-    sub can        { my ( $s, $m ) = @_; $m eq 'title' ? 0 : $s->SUPER::can($m) }
+    sub can { my ( $s, $m ) = @_; $m eq 'title' ? 0 : $s->SUPER::can($m) }
 }
 
 my $greek_chars = "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}";
 my $greek_bytes = encode_utf8($greek_chars);
 
-subtest 'cookie value with raw UTF-8 bytes renders as decoded characters' => sub {
+subtest 'cookie value with raw UTF-8 bytes renders as decoded characters' =>
+    sub {
     my @captured;
     my $logger = Log::Dispatch->new(
         outputs => [
@@ -39,13 +40,13 @@ subtest 'cookie value with raw UTF-8 bytes renders as decoded characters' => sub
 
     my $jar = HTTP::Cookies->new;
     $jar->set_cookie(
-        0,                  # version
-        'greek',            # key
-        $greek_bytes,       # val (raw UTF-8 bytes)
-        '/',                # path
-        'example.com',      # domain
-        undef, 0, 0,        # port, path_spec, secure
-        86400,              # maxage
+        0,                # version
+        'greek',          # key
+        $greek_bytes,     # val (raw UTF-8 bytes)
+        '/',              # path
+        'example.com',    # domain
+        undef, 0, 0,      # port, path_spec, secure
+        86400,            # maxage
     );
 
     my $cl = LWP::ConsoleLogger->new(
@@ -57,18 +58,25 @@ subtest 'cookie value with raw UTF-8 bytes renders as decoded characters' => sub
     );
 
     my $req = HTTP::Request->new( GET => 'http://example.com/' );
-    my $res = HTTP::Response->new( 200, 'OK',
-        HTTP::Headers->new( 'Content-Type' => 'text/plain' ), 'body' );
+    my $res = HTTP::Response->new(
+        200,                                                  'OK',
+        HTTP::Headers->new( 'Content-Type' => 'text/plain' ), 'body'
+    );
     $res->request($req);
 
     $cl->response_callback( $res, Fake::UA->new($jar) );
 
     my $all = join "\n", @captured;
-    like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in cookie output' );
+    like(
+        $all, qr/\Q$greek_chars\E/,
+        'Greek characters present in cookie output'
+    );
     unlike( $all, qr/Î±Î¹/, 'no mojibake in cookie output' );
-};
+    };
 
-subtest 'HTTP::CookieJar value with raw UTF-8 bytes renders as decoded characters' => sub {
+subtest
+    'HTTP::CookieJar value with raw UTF-8 bytes renders as decoded characters'
+    => sub {
     my @captured;
     my $logger = Log::Dispatch->new(
         outputs => [
@@ -84,7 +92,10 @@ subtest 'HTTP::CookieJar value with raw UTF-8 bytes renders as decoded character
     );
 
     my $jar = HTTP::CookieJar::LWP->new;
-    $jar->add( 'http://example.com/', "greek=$greek_bytes; Path=/; Max-Age=86400" );
+    $jar->add(
+        'http://example.com/',
+        "greek=$greek_bytes; Path=/; Max-Age=86400"
+    );
 
     my $cl = LWP::ConsoleLogger->new(
         logger       => $logger,
@@ -95,15 +106,20 @@ subtest 'HTTP::CookieJar value with raw UTF-8 bytes renders as decoded character
     );
 
     my $req = HTTP::Request->new( GET => 'http://example.com/' );
-    my $res = HTTP::Response->new( 200, 'OK',
-        HTTP::Headers->new( 'Content-Type' => 'text/plain' ), 'body' );
+    my $res = HTTP::Response->new(
+        200,                                                  'OK',
+        HTTP::Headers->new( 'Content-Type' => 'text/plain' ), 'body'
+    );
     $res->request($req);
 
     $cl->response_callback( $res, Fake::UA->new($jar) );
 
     my $all = join "\n", @captured;
-    like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in CookieJar output' );
+    like(
+        $all, qr/\Q$greek_chars\E/,
+        'Greek characters present in CookieJar output'
+    );
     unlike( $all, qr/Î±Î¹/, 'no mojibake in CookieJar output' );
-};
+    };
 
 done_testing;

--- a/t/utf8-cookies.t
+++ b/t/utf8-cookies.t
@@ -2,8 +2,9 @@ use strict;
 use warnings;
 
 use Encode       qw( encode_utf8 );
-use HTTP::Cookies   ();
-use HTTP::Headers   ();
+use HTTP::Cookies      ();
+use HTTP::CookieJar::LWP ();
+use HTTP::Headers      ();
 use HTTP::Request   ();
 use HTTP::Response  ();
 use Log::Dispatch   ();
@@ -65,6 +66,44 @@ subtest 'cookie value with raw UTF-8 bytes renders as decoded characters' => sub
     my $all = join "\n", @captured;
     like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in cookie output' );
     unlike( $all, qr/Î±Î¹/, 'no mojibake in cookie output' );
+};
+
+subtest 'HTTP::CookieJar value with raw UTF-8 bytes renders as decoded characters' => sub {
+    my @captured;
+    my $logger = Log::Dispatch->new(
+        outputs => [
+            [
+                'Code',
+                min_level => 'debug',
+                code      => sub {
+                    my %args = @_;
+                    push @captured, $args{message};
+                },
+            ],
+        ],
+    );
+
+    my $jar = HTTP::CookieJar::LWP->new;
+    $jar->add( 'http://example.com/', "greek=$greek_bytes; Path=/; Max-Age=86400" );
+
+    my $cl = LWP::ConsoleLogger->new(
+        logger       => $logger,
+        dump_cookies => 1,
+        dump_content => 0,
+        dump_text    => 0,
+        dump_headers => 0,
+    );
+
+    my $req = HTTP::Request->new( GET => 'http://example.com/' );
+    my $res = HTTP::Response->new( 200, 'OK',
+        HTTP::Headers->new( 'Content-Type' => 'text/plain' ), 'body' );
+    $res->request($req);
+
+    $cl->response_callback( $res, Fake::UA->new($jar) );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in CookieJar output' );
+    unlike( $all, qr/Î±Î¹/, 'no mojibake in CookieJar output' );
 };
 
 done_testing;

--- a/t/utf8-cookies.t
+++ b/t/utf8-cookies.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+
+use Encode       qw( encode_utf8 );
+use HTTP::Cookies   ();
+use HTTP::Headers   ();
+use HTTP::Request   ();
+use HTTP::Response  ();
+use Log::Dispatch   ();
+use LWP::ConsoleLogger ();
+use Test::More import => [qw( done_testing like unlike subtest )];
+use Test::Warnings;
+
+{
+    package Fake::UA;
+    sub new        { bless { jar => $_[1] }, $_[0] }
+    sub cookie_jar { $_[0]->{jar} }
+    sub can        { my ( $s, $m ) = @_; $m eq 'title' ? 0 : $s->SUPER::can($m) }
+}
+
+my $greek_chars = "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}";
+my $greek_bytes = encode_utf8($greek_chars);
+
+subtest 'cookie value with raw UTF-8 bytes renders as decoded characters' => sub {
+    my @captured;
+    my $logger = Log::Dispatch->new(
+        outputs => [
+            [
+                'Code',
+                min_level => 'debug',
+                code      => sub {
+                    my %args = @_;
+                    push @captured, $args{message};
+                },
+            ],
+        ],
+    );
+
+    my $jar = HTTP::Cookies->new;
+    $jar->set_cookie(
+        0,                  # version
+        'greek',            # key
+        $greek_bytes,       # val (raw UTF-8 bytes)
+        '/',                # path
+        'example.com',      # domain
+        undef, 0, 0,        # port, path_spec, secure
+        86400,              # maxage
+    );
+
+    my $cl = LWP::ConsoleLogger->new(
+        logger       => $logger,
+        dump_cookies => 1,
+        dump_content => 0,
+        dump_text    => 0,
+        dump_headers => 0,
+    );
+
+    my $req = HTTP::Request->new( GET => 'http://example.com/' );
+    my $res = HTTP::Response->new( 200, 'OK',
+        HTTP::Headers->new( 'Content-Type' => 'text/plain' ), 'body' );
+    $res->request($req);
+
+    $cl->response_callback( $res, Fake::UA->new($jar) );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in cookie output' );
+    unlike( $all, qr/Î±Î¹/, 'no mojibake in cookie output' );
+};
+
+done_testing;

--- a/t/utf8-headers.t
+++ b/t/utf8-headers.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+
+use Encode      qw( encode_utf8 );
+use HTTP::Request  ();
+use HTTP::Response ();
+use Log::Dispatch  ();
+use LWP::ConsoleLogger ();
+use Test::More import => [qw( done_testing is ok subtest like unlike )];
+use Test::Warnings;
+
+# Anonymous fake UA — has no title() and a no-op cookie_jar
+{
+    package Fake::UA;
+    sub new        { bless {}, shift }
+    sub cookie_jar { undef }
+    sub can        { my ( $s, $m ) = @_; $m eq 'title' ? 0 : $s->SUPER::can($m) }
+}
+
+sub make_logger {
+    my $captured = shift;    # arrayref the caller wants populated
+    return Log::Dispatch->new(
+        outputs => [
+            [
+                'Code',
+                min_level => 'debug',
+                code      => sub {
+                    my %args = @_;
+                    push @{$captured}, $args{message};
+                },
+            ],
+        ],
+    );
+}
+
+sub make_response {
+    my %args = @_;
+    my $headers = HTTP::Headers->new(
+        'Content-Type' => 'text/plain; charset=utf-8',
+        Title          => $args{title},
+    );
+    my $res = HTTP::Response->new( 200, 'OK', $headers, 'body' );
+    $res->request( HTTP::Request->new( GET => 'http://example.com/' ) );
+    return $res;
+}
+
+my $greek_chars = "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}";
+my $greek_bytes = encode_utf8($greek_chars);
+my $mojibake    = "\xC3\x8E\xC2\xB1";    # what Î± looks like double-encoded
+
+subtest 'raw UTF-8 bytes in Title header render correctly (pretty)' => sub {
+    my @captured;
+    my $cl = LWP::ConsoleLogger->new(
+        logger       => make_logger( \@captured ),
+        dump_content => 0,
+        dump_text    => 0,
+    );
+    $cl->response_callback( make_response( title => $greek_bytes ),
+        Fake::UA->new );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in output' );
+    unlike( $all, qr/Î±Î¹/, 'no mojibake in output' );
+};
+
+done_testing;

--- a/t/utf8-headers.t
+++ b/t/utf8-headers.t
@@ -81,4 +81,28 @@ subtest 'raw UTF-8 bytes in Title header render correctly (pretty=>0)' => sub {
     unlike( $all, qr/Î±Î¹/, 'no mojibake' );
 };
 
+subtest 'multi-value header emits one line per value (non-pretty)' => sub {
+    my @captured;
+    my $cl = LWP::ConsoleLogger->new(
+        logger       => make_logger( \@captured ),
+        pretty       => 0,
+        dump_content => 0,
+        dump_headers => 1,
+        dump_text    => 0,
+    );
+
+    my $headers = HTTP::Headers->new( 'Content-Type' => 'text/plain' );
+    $headers->push_header( 'Set-Cookie' => 'a=1' );
+    $headers->push_header( 'Set-Cookie' => 'b=2' );
+    my $res = HTTP::Response->new( 200, 'OK', $headers, 'body' );
+    $res->request( HTTP::Request->new( GET => 'http://example.com/' ) );
+
+    $cl->response_callback( $res, Fake::UA->new );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/Set-Cookie: a=1\b/, 'first cookie on its own line' );
+    like( $all, qr/Set-Cookie: b=2\b/, 'second cookie on its own line' );
+    unlike( $all, qr/Set-Cookie: a=1, b=2/, 'values are not comma-joined' );
+};
+
 done_testing;

--- a/t/utf8-headers.t
+++ b/t/utf8-headers.t
@@ -1,11 +1,11 @@
 use strict;
 use warnings;
 
-use Encode      qw( encode_utf8 );
-use HTTP::Headers  ();
-use HTTP::Request  ();
-use HTTP::Response ();
-use Log::Dispatch  ();
+use Encode             qw( encode_utf8 );
+use HTTP::Headers      ();
+use HTTP::Request      ();
+use HTTP::Response     ();
+use Log::Dispatch      ();
 use LWP::ConsoleLogger ();
 use Test::More import => [qw( done_testing subtest like unlike )];
 use Test::Warnings;
@@ -15,7 +15,7 @@ use Test::Warnings;
     package Fake::UA;
     sub new        { bless {}, shift }
     sub cookie_jar { undef }
-    sub can        { my ( $s, $m ) = @_; $m eq 'title' ? 0 : $s->SUPER::can($m) }
+    sub can { my ( $s, $m ) = @_; $m eq 'title' ? 0 : $s->SUPER::can($m) }
 }
 
 sub make_logger {
@@ -35,7 +35,7 @@ sub make_logger {
 }
 
 sub make_response {
-    my %args = @_;
+    my %args    = @_;
     my $headers = HTTP::Headers->new(
         'Content-Type' => 'text/plain; charset=utf-8',
         Title          => $args{title},
@@ -56,15 +56,18 @@ subtest 'raw UTF-8 bytes in Title header render correctly (pretty)' => sub {
         dump_text    => 0,
         pretty       => 1,
     );
-    $cl->response_callback( make_response( title => $greek_bytes ),
-        Fake::UA->new );
+    $cl->response_callback(
+        make_response( title => $greek_bytes ),
+        Fake::UA->new
+    );
 
     my $all = join "\n", @captured;
     like( $all, qr/\Q$greek_chars\E/, 'Greek characters present in output' );
     unlike( $all, qr/Î±Î¹/, 'no mojibake in output' );
 };
 
-subtest 'raw UTF-8 bytes in Title header render correctly (pretty=>0)' => sub {
+subtest 'raw UTF-8 bytes in Title header render correctly (pretty=>0)' =>
+    sub {
     my @captured;
     my $cl = LWP::ConsoleLogger->new(
         logger       => make_logger( \@captured ),
@@ -72,14 +75,18 @@ subtest 'raw UTF-8 bytes in Title header render correctly (pretty=>0)' => sub {
         dump_content => 0,
         dump_text    => 0,
     );
-    $cl->response_callback( make_response( title => $greek_bytes ),
-        Fake::UA->new );
+    $cl->response_callback(
+        make_response( title => $greek_bytes ),
+        Fake::UA->new
+    );
 
     my $all = join "\n", @captured;
-    like( $all, qr/Title: \Q$greek_chars\E/,
-        'Greek characters present after Title: prefix' );
+    like(
+        $all, qr/Title: \Q$greek_chars\E/,
+        'Greek characters present after Title: prefix'
+    );
     unlike( $all, qr/Î±Î¹/, 'no mojibake' );
-};
+    };
 
 subtest 'multi-value header emits one line per value (non-pretty)' => sub {
     my @captured;
@@ -110,7 +117,8 @@ subtest 'multi-value header emits one line per value (non-pretty)' => sub {
     sub new        { bless { title => $_[1] }, $_[0] }
     sub cookie_jar { undef }
     sub title      { $_[0]->{title} }
-    sub can        {
+
+    sub can {
         my ( $s, $m ) = @_;
         return 1 if $m eq 'title';
         return $s->SUPER::can($m);
@@ -124,11 +132,16 @@ subtest 'ua title with raw UTF-8 bytes renders as decoded characters' => sub {
         dump_content => 0,
         dump_text    => 0,
     );
-    $cl->response_callback( make_response( title => 'plain' ),
-        Fake::UA::WithTitle->new($greek_bytes) );
+    $cl->response_callback(
+        make_response( title => 'plain' ),
+        Fake::UA::WithTitle->new($greek_bytes)
+    );
 
     my $all = join "\n", @captured;
-    like( $all, qr/Title: \Q$greek_chars\E/, 'Title line shows decoded chars' );
+    like(
+        $all, qr/Title: \Q$greek_chars\E/,
+        'Title line shows decoded chars'
+    );
     unlike( $all, qr/Title: Î/, 'Title is not mojibake' );
 };
 

--- a/t/utf8-headers.t
+++ b/t/utf8-headers.t
@@ -2,11 +2,12 @@ use strict;
 use warnings;
 
 use Encode      qw( encode_utf8 );
+use HTTP::Headers  ();
 use HTTP::Request  ();
 use HTTP::Response ();
 use Log::Dispatch  ();
 use LWP::ConsoleLogger ();
-use Test::More import => [qw( done_testing is ok subtest like unlike )];
+use Test::More import => [qw( done_testing subtest like unlike )];
 use Test::Warnings;
 
 # Anonymous fake UA — has no title() and a no-op cookie_jar
@@ -46,14 +47,14 @@ sub make_response {
 
 my $greek_chars = "\x{03B1}\x{03B9}\x{03C1}\x{03B5}\x{03AF}\x{03B1}";
 my $greek_bytes = encode_utf8($greek_chars);
-my $mojibake    = "\xC3\x8E\xC2\xB1";    # what Î± looks like double-encoded
-
 subtest 'raw UTF-8 bytes in Title header render correctly (pretty)' => sub {
     my @captured;
     my $cl = LWP::ConsoleLogger->new(
         logger       => make_logger( \@captured ),
         dump_content => 0,
+        dump_headers => 1,
         dump_text    => 0,
+        pretty       => 1,
     );
     $cl->response_callback( make_response( title => $greek_bytes ),
         Fake::UA->new );

--- a/t/utf8-headers.t
+++ b/t/utf8-headers.t
@@ -105,4 +105,31 @@ subtest 'multi-value header emits one line per value (non-pretty)' => sub {
     unlike( $all, qr/Set-Cookie: a=1, b=2/, 'values are not comma-joined' );
 };
 
+{
+    package Fake::UA::WithTitle;
+    sub new        { bless { title => $_[1] }, $_[0] }
+    sub cookie_jar { undef }
+    sub title      { $_[0]->{title} }
+    sub can        {
+        my ( $s, $m ) = @_;
+        return 1 if $m eq 'title';
+        return $s->SUPER::can($m);
+    }
+}
+
+subtest 'ua title with raw UTF-8 bytes renders as decoded characters' => sub {
+    my @captured;
+    my $cl = LWP::ConsoleLogger->new(
+        logger       => make_logger( \@captured ),
+        dump_content => 0,
+        dump_text    => 0,
+    );
+    $cl->response_callback( make_response( title => 'plain' ),
+        Fake::UA::WithTitle->new($greek_bytes) );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/Title: \Q$greek_chars\E/, 'Title line shows decoded chars' );
+    unlike( $all, qr/Title: Î/, 'Title is not mojibake' );
+};
+
 done_testing;

--- a/t/utf8-headers.t
+++ b/t/utf8-headers.t
@@ -64,4 +64,21 @@ subtest 'raw UTF-8 bytes in Title header render correctly (pretty)' => sub {
     unlike( $all, qr/Î±Î¹/, 'no mojibake in output' );
 };
 
+subtest 'raw UTF-8 bytes in Title header render correctly (pretty=>0)' => sub {
+    my @captured;
+    my $cl = LWP::ConsoleLogger->new(
+        logger       => make_logger( \@captured ),
+        pretty       => 0,
+        dump_content => 0,
+        dump_text    => 0,
+    );
+    $cl->response_callback( make_response( title => $greek_bytes ),
+        Fake::UA->new );
+
+    my $all = join "\n", @captured;
+    like( $all, qr/Title: \Q$greek_chars\E/,
+        'Greek characters present after Title: prefix' );
+    unlike( $all, qr/Î±Î¹/, 'no mojibake' );
+};
+
 done_testing;


### PR DESCRIPTION
Closes #38

## Changes

- Add a private `_decode_header_value` helper on `LWP::ConsoleLogger` that decodes wire-byte values to character strings using UTF-8 with a Latin-1 fallback. Already-decoded inputs (utf8-flagged) pass through unchanged.
- Wire the helper into every log call site that previously fed raw bytes to `Log::Dispatch`:
  - `_log_headers` pretty mode (per-header)
  - `_log_headers` non-pretty mode (per-value, list context — preserves multi-value parity with `as_string` for headers like `Set-Cookie`)
  - `_log_cookies` (`HTTP::Cookies` and `HTTP::CookieJar` branches)
  - `$ua->title` line in `response_callback`
- Open the `LWPCL_LOGFILE` log file in `LWP::ConsoleLogger::Everywhere` with `binmode => ':encoding(UTF-8)'` to stop "Wide character in print" warnings on body content.
- Declare `Encode` (runtime) and `IPC::Run3` (test) in `dist.ini`.
- Add a `Changes` entry.

The original reporter's workaround (`Log::Dispatch` with `utf8 => 0`) is no longer required — the default `Screen` logger now renders non-ASCII headers, cookies, and titles correctly without any opt-in.

## Testing

- New `t/decode-header-value.t` covers the helper across undef, empty, ASCII, raw UTF-8 bytes, invalid UTF-8 (Latin-1 fallback), and already-decoded inputs.
- New `t/utf8-headers.t` exercises the pretty and non-pretty `_log_headers` branches with Greek `αιρεία` bytes, multi-value `Set-Cookie`, and the `$ua->title` line — asserts decoded characters appear and mojibake does not.
- New `t/utf8-cookies.t` covers both `HTTP::Cookies` and `HTTP::CookieJar` branches.
- Extended `t/unicode.t` adds (a) a `Log::Dispatch::Code` capture that asserts 😄 from the body appears in the logged output and (b) a `Log::Dispatch::File` output writing to a tempfile, wrapped in `Test::Warnings` to fail on any "Wide character in print" warning.
- New `t/everywhere-logfile.t` spawns a subprocess via `IPC::Run3` (because `LWPCL_LOGFILE` is read at `use` time) and verifies the log file contains UTF-8 bytes with no warnings on stderr.

All 46 task-related tests pass. The pre-existing `t/pretty.t` failure ("empty port not found") is present on `main` too and is unrelated.