### PR TITLE
Silence Wide character warnings in t/wide-chars.t

### DIFF
--- a/t/wide-chars.t
+++ b/t/wide-chars.t
@@ -1,16 +1,27 @@
 use strict;
 use warnings;
 
-use Test::More import => [qw( done_testing is ok )];
-use Test::Needs 'Unicode::GCString';
-
 use LWP::ConsoleLogger::Easy qw( debug_ua );
 use LWP::UserAgent           ();
 use Log::Dispatch            ();
 use Log::Dispatch::Array     ();
 use Path::Tiny               qw( path );
+use Test::More import => [qw( done_testing is ok )];
+use Test::Needs 'Unicode::GCString';
+use Test::Warnings;
 
 require Unicode::GCString;
+
+# The captured table rows contain CJK glyphs and get interpolated into
+# is() test names below; without UTF-8 binmode on the TAP filehandles,
+# Test2::Formatter::TAP emits "Wide character in print" warnings.
+for my $fh (
+    Test::More->builder->output,
+    Test::More->builder->failure_output,
+    Test::More->builder->todo_output,
+) {
+    binmode $fh, ':encoding(UTF-8)';
+}
 
 my $ua = LWP::UserAgent->new;
 
@@ -25,7 +36,8 @@ my $logger = debug_ua($ua);
 
 my $messages = [];
 my $ld       = Log::Dispatch->new(
-    outputs => [ [ 'Screen', min_level => 'debug', newline => 1 ] ],
+    outputs =>
+        [ [ 'Screen', min_level => 'debug', newline => 1, utf8 => 1 ] ],
 );
 $ld->add(
     Log::Dispatch::Array->new(


### PR DESCRIPTION
Closes #58

## Changes

`t/wide-chars.t` was emitting `Wide character in print` warnings even though the test passed. Two filehandles were receiving wide chars without UTF-8 binmode:

1. **`Log::Dispatch::Screen`** — the test built its own logger and omitted the `utf8 => 1` flag that `LWP::ConsoleLogger`'s default at `lib/LWP/ConsoleLogger.pm:106` already sets.
2. **`Test2::Formatter::TAP`** — CJK-containing rows were interpolated into `is()` test names, and the TAP filehandle had no UTF-8 binmode.

Test-only changes:

- Add `utf8 => 1` to the test's `Screen` output (mirrors the library's own default).
- Set `:encoding(UTF-8)` binmode on `Test::More`'s builder filehandles so TAP can print CJK test names cleanly.
- Add `use Test::Warnings` so any regression fails the test (matches the convention used in `t/unicode.t`, `t/utf8-headers.t`, `t/utf8-cookies.t`, `t/decode-header-value.t`, `t/everywhere-logfile.t`).
- Reorder imports so `Test::Warnings` is loaded last (mirrors `t/unicode.t` — so module-load warnings aren't captured).

The library itself was already correct; this is purely a test-setup fix.

## Testing

- `prove -lv t/wide-chars.t` → 27/27 pass, zero `Wide character in print` warnings emitted.
- `Test::Warnings` adds an extra assertion (`ok 27 - no (unexpected) warnings`) that will catch any regression.
- `precious lint t/wide-chars.t` → clean.